### PR TITLE
既存モデルの変更 add_column のオプションの記述方法を修正

### DIFF
--- a/db/migrate/20230228130514_add_column_to_tasks.rb
+++ b/db/migrate/20230228130514_add_column_to_tasks.rb
@@ -1,6 +1,6 @@
 class AddColumnToTasks < ActiveRecord::Migration[7.0]
   def change
-    add_column :tasks, :user_id, :integer, :null => false 
-    add_column :tasks, :done, :boolean, :null => false, :default => false
+    add_column :tasks, :user_id, :integer, null: false 
+    add_column :tasks, :done, :boolean, null: false, default: false
   end
 end

--- a/db/migrate/20230313144307_add_user_to_tasks.rb
+++ b/db/migrate/20230313144307_add_user_to_tasks.rb
@@ -1,6 +1,6 @@
 class AddUserToTasks < ActiveRecord::Migration[7.0]
   def change
-    remove_column :tasks, :user_id, :integer, :null => false
+    remove_column :tasks, :user_id, :integer, null: false
     add_reference :tasks, :user, null: false, foreign_key: true
   end
 end


### PR DESCRIPTION
マイグレーションファイルの記述に古い（Ruby1.8頃の）シンボルをキーとした Hash オブジェクトの記法が混ざっていた（というか採用されている部分がある）のが気になったので修正する差分です。